### PR TITLE
[버그 수정] 화면 새로고침

### DIFF
--- a/App.js
+++ b/App.js
@@ -10,6 +10,7 @@ function App() {
     storeData("users", db.users);
     storeData("comments", db.comments);
   }, []);
+
   return (
     <NavigationContainer>
       <StackNavigator />

--- a/src/components/WeekStrip.js
+++ b/src/components/WeekStrip.js
@@ -6,7 +6,6 @@ import CalendarStrip from "react-native-calendar-strip";
 import { theme } from "../theme";
 import HomeTasks from "./task/HomeTasks";
 import useSetDate from "../hooks/useSetDate";
-import useGetData from "../hooks/useGetData";
 
 const WeekStrip = ({
   tasks,
@@ -31,6 +30,7 @@ const WeekStrip = ({
 
   // Get date from CalendarScreen
   useEffect(() => {
+    console.log(route.params);
     passDate(route);
     setRefresh((current) => !current); // Refresh screen
   }, [route.params]);

--- a/src/components/common/Footer.js
+++ b/src/components/common/Footer.js
@@ -1,5 +1,6 @@
 import React, { useState } from "react";
 import styled from "styled-components/native";
+import { View } from "react-native";
 
 import { images } from "../../images";
 import { theme } from "../../theme";
@@ -78,7 +79,7 @@ const Footer = ({
           (item) => item.selected === false
         );
         // Delete tasks of all tasks
-          _tasks.push(...unSelectedTasks);
+        _tasks.push(...unSelectedTasks);
         // Delete tasks of categories
         _categories[i].tasks = unSelectedTasks;
       }
@@ -89,7 +90,7 @@ const Footer = ({
     storeData("categories", _categories);
     setIsSelecting(false);
     setAll(false);
-    setRefresh(current => !current);
+    setRefresh((current) => !current);
   };
 
   return (
@@ -99,12 +100,14 @@ const Footer = ({
           type={type}
           onPressOut={() => screens[0] && navigation.navigate(screens[0])}
         />
-      ) : (
+      ) : where === "all" ? (
         <AllButton all={all} onPress={selectAll} isSelecting={isSelecting}>
           <AllText all={all} isSelecting={isSelecting}>
             All
           </AllText>
         </AllButton>
+      ) : (
+        <View />
       )}
 
       <RightButtons>

--- a/src/components/task/TaskItem.js
+++ b/src/components/task/TaskItem.js
@@ -84,12 +84,12 @@ const TaskItem = ({
       <Animated.View style={styles.animatedView}>
         <LeftItems>
           <IconButton type={returnIcon(item)} onPressOut={toggleItem} />
-          <StyledText>
+          <StyledView>
             <TaskText>{item.text}</TaskText>
             {item.due && (
               <DueDate>{new Date(item.due).toLocaleDateString()}</DueDate>
             )}
-          </StyledText>
+          </StyledView>
         </LeftItems>
         <RightItems>
           {item.image && (
@@ -101,12 +101,11 @@ const TaskItem = ({
           )}
           <IconButton
             type={images.edit}
-            // selectedTask(선택한 task), category(선택한 task가 속한 카테고리 객체), isAddPressed(추가인지 편집인지 구분, 새로 추가면 true 편집이면 false)
             onPressOut={() =>
               navigation.navigate("EditScreen", {
-                selectedTask: item,
-                category: findCategory(item),
-                isAddPressed: false,
+                selectedTask: item, // 선택한 task
+                category: findCategory(item), // 선택한 task가 속한 카테고리 객체
+                isAddPressed: false, // 추가인지 편집인지 구분, 새로 추가면 true 편집이면 false
               })
             }
           />
@@ -134,7 +133,7 @@ const Touchable = styled.TouchableOpacity`
     props.isActive || props.selected ? theme.light : theme.background};
 `;
 
-const StyledText = styled.View`
+const StyledView = styled.View`
   flex-direction: column;
   margin-left: 5px;
 `;

--- a/src/components/task/TaskItem.js
+++ b/src/components/task/TaskItem.js
@@ -52,7 +52,7 @@ const TaskItem = ({
   };
 
   const returnIcon = () => {
-    return isCompleted ? images.complete : images.uncomplete;
+    return item.complete ? images.complete : images.uncomplete;
   };
 
   const selectItem = () => {

--- a/src/hooks/useGetData.js
+++ b/src/hooks/useGetData.js
@@ -17,6 +17,7 @@ const useGetData = () => {
       console.log(error);
     }
   };
+
   return { categories, tasks, setCategories, setTasks, getDataFirst };
 };
 

--- a/src/screens/AllCategory.js
+++ b/src/screens/AllCategory.js
@@ -60,7 +60,7 @@ const AllCategory = ({ navigation }) => {
     setState(false);
   };
 
-  console.log(categories);
+  // console.log(categories);
 
   const _onPressCancel = () => {
     setNewCategory("");
@@ -75,41 +75,42 @@ const AllCategory = ({ navigation }) => {
     setRefresh((current) => setRefresh(!current));
   };
 
-  const renderItem = ({item, index}) => {
-      return (
-        <Categories
+  const renderItem = ({ item, index }) => {
+    return (
+      <Categories
         key={index}
         item={item}
         doRefresh={doRefresh}
         navigation={navigation}
       />
-      )
-  }
+    );
+  };
   return isReady ? (
-    <FlatList style={{backgroundColor: theme.background}}
-    ListHeaderComponent={
-    <Wrapper>
-    <StyledBar barStyle="default" />
-      <StyledView width={width - 20}>
-        <IconButton
-          type={images.add}
-          onPressOut={() => {
-            setState(true);
-          }}
-        />
-        <AddCategory
-            state={state}
-            value={newCategory}
-            onCancel={_onPressCancel}
-            setColor={setColor}
-            onChangeText={_handleTextChange}
-            onConfirm={addCategory}
-        />
-    </StyledView>
-</Wrapper>
-    }
-    data={categories}
-    renderItem={renderItem}
+    <FlatList
+      style={{ backgroundColor: theme.background }}
+      ListHeaderComponent={
+        <Wrapper>
+          <StyledBar barStyle="default" />
+          <StyledView width={width - 20}>
+            <IconButton
+              type={images.add}
+              onPressOut={() => {
+                setState(true);
+              }}
+            />
+            <AddCategory
+              state={state}
+              value={newCategory}
+              onCancel={_onPressCancel}
+              setColor={setColor}
+              onChangeText={_handleTextChange}
+              onConfirm={addCategory}
+            />
+          </StyledView>
+        </Wrapper>
+      }
+      data={categories}
+      renderItem={renderItem}
     />
   ) : (
     <AppLoading

--- a/src/screens/AllTasks.js
+++ b/src/screens/AllTasks.js
@@ -1,10 +1,11 @@
-import React, { useState, useRef, useEffect } from "react";
+import React, { useState, useRef } from "react";
 import styled from "styled-components/native";
 import DraggableFlatList, {
   ScaleDecorator,
   ShadowDecorator,
   OpacityDecorator,
 } from "react-native-draggable-flatlist";
+import { useFocusEffect } from "@react-navigation/native";
 
 import { theme } from "../theme";
 import Dropdown from "../components/common/Dropdown";
@@ -16,7 +17,13 @@ import ImageDialog from "../components/task/ImageDialog";
 const AllTasks = ({ navigation }) => {
   const { categories, tasks, setCategories, setTasks, getDataFirst } =
     useGetData();
-  useEffect(getDataFirst, []);
+
+  useFocusEffect(
+    React.useCallback(() => {
+      getDataFirst();
+      return () => {};
+    }, [])
+  );
 
   const ref = useRef(null);
   const [refresh, setRefresh] = useState(false);

--- a/src/screens/AllTasks.js
+++ b/src/screens/AllTasks.js
@@ -18,19 +18,19 @@ const AllTasks = ({ navigation }) => {
   const { categories, tasks, setCategories, setTasks, getDataFirst } =
     useGetData();
 
-  useFocusEffect(
-    React.useCallback(() => {
-      getDataFirst();
-      return () => {};
-    }, [])
-  );
-
   const ref = useRef(null);
   const [refresh, setRefresh] = useState(false);
   const [sorting, setSorting] = useState("added");
   const [isSelecting, setIsSelecting] = useState(false);
   const [modalVisible, setModalVisible] = useState(false);
   const [imagePath, setImagePath] = useState(null);
+
+  useFocusEffect(
+    React.useCallback(() => {
+      getDataFirst();
+      return () => {};
+    }, [])
+  );
 
   const sortTasks = () => {
     const _tasks = tasks;

--- a/src/screens/Home.js
+++ b/src/screens/Home.js
@@ -1,5 +1,6 @@
-import React, { useEffect, useState } from "react";
+import React, { useState } from "react";
 import styled from "styled-components/native";
+import { useFocusEffect } from "@react-navigation/native";
 
 import Footer from "../components/common/Footer";
 import WeekStrip from "../components/WeekStrip";
@@ -10,7 +11,13 @@ import useGetData from "../hooks/useGetData";
 const Home = ({ navigation, route }) => {
   const { categories, tasks, setCategories, setTasks, getDataFirst } =
     useGetData();
-  useEffect(getDataFirst, []);
+
+  useFocusEffect(
+    React.useCallback(() => {
+      getDataFirst();
+      return () => {};
+    }, [])
+  );
 
   const [isSelecting, setIsSelecting] = useState(false);
   const [refresh, setRefresh] = useState(false);


### PR DESCRIPTION
## 해결방법
- 화면 별로 useFocusEffect 사용 --> https://reactnavigation.org/docs/use-focus-effect
- 다중 삭제, 테스크 수정, 토글 연동
- 토글은 state 대신 item object를 직접 넘겨서 해결

## Screenshots
<img width="35%" src="https://user-images.githubusercontent.com/70844774/146577739-08715049-50ad-421b-9b7c-8ef9de0622f3.gif" />

## 더 필요한 점
- Home 새로 고침이 느리다.
- 할 일 추가 시 오류 발생 **_Text strings must be rendered within a <Text> component._** → getDataFirst
- Calendar screen에서 undefined가 넘어온다.
  - Drawer navigation 살펴보기 https://reactnavigation.org/docs/use-focus-effect
